### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/cambridge-medium/_schema.yml
+++ b/_extensions/cambridge-medium/_schema.yml
@@ -1,0 +1,22 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+formats:
+  cambridge-medium-pdf:
+    classoption:
+      type: array
+      description: Cambridge class options including journal presets and layout switches.
+      items:
+        type: string
+    number-sections:
+      type: boolean
+      description: Enable section numbering in the manuscript.
+    toc:
+      type: boolean
+      description: Enable or disable table of contents rendering.
+    fontfamily:
+      type: string
+      description: Main LaTeX font family identifier.
+    cite-method:
+      type: string
+      enum: [biblatex, natbib]
+      description: Citation processing method for PDF output.

--- a/_extensions/cambridge-medium/_snippets.json
+++ b/_extensions/cambridge-medium/_snippets.json
@@ -1,0 +1,20 @@
+{
+  "Cambridge format setup": {
+    "prefix": "format",
+    "body": [
+      "format:",
+      "  cambridge-medium-pdf: default"
+    ],
+    "description": "Enable Cambridge Medium PDF format."
+  },
+  "Cambridge journal option": {
+    "prefix": "journal",
+    "body": [
+      "format:",
+      "  cambridge-medium-pdf:",
+      "    classoption:",
+      "      - ${1:medium}"
+    ],
+    "description": "Set a Cambridge journal class option such as medium, jog, or pa."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/cambridge-medium/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/cambridge-medium/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html


---

Feel free to close, as for format extensions, the schema does not bring much, until there is a way to provide the base format completion.